### PR TITLE
ci: Bump all os versions to `latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-18.04
-          - windows-2019
-          - macos-10.15
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
         go:
           - 1.14
           - 1.15


### PR DESCRIPTION
[The issue](https://github.com/actions/runner-images/issues/4856), why we pinned the windows version to 2019, should be resolved by now.

Furthermore, I see no reason not to use `latest` for ubuntu and macOS as well.