### PR TITLE
Add copywrite config

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,7 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2021
+  header_ignore  = []
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/hashicorp/terraform-registry-address/pull/19 to make it easier for copywrite CLI to establish the right year in the header and easier to add any files/patterns to ignore later.