### PR TITLE
Reenable Dependabot for internal GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,10 @@ updates:
     schedule:
       interval: "daily"
     labels: ["dependencies"]
+  # Dependabot only updates hashicorp GHAs, external GHAs are managed by internal tooling (tsccr)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "hashicorp/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,20 @@ updates:
     schedule:
       interval: "daily"
     labels: ["dependencies"]
-  # Dependabot only updates hashicorp GHAs, external GHAs are managed by internal tooling (tsccr)
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
+      interval: weekly
+    labels:
+      - dependencies
+    # only update HashiCorp actions, external actions managed by TSCCR
     allow:
-      - dependency-name: "hashicorp/*"
+      - dependency-name: hashicorp/*
+    groups:
+      github-actions-breaking:
+        update-types:
+          - major
+      github-actions-backward-compatible:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
When TSCCR was first introduced, it was not clear that the tool would only update external GitHub actions. This adds the configuration to enable `hashicorp/*` action updates.