### PR TITLE
fix `ValidateProviderAddress` + Introduce `Provider.Validate` + `Provider` (un)marshaler interfaces

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -215,6 +215,25 @@ func (pt Provider) LessThan(other Provider) bool {
 	}
 }
 
+// MarshalText implements encoding.TextMarshaler interface.
+//
+// It encodes the [Provider] into an FQN, equivalent to [String].
+func (pt Provider) MarshalText() ([]byte, error) {
+	return []byte(pt.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+//
+// It decodes a valid provider address or returns an error
+// using [ParseProviderSource].
+//
+// [Validate] should be called on the decoded [Provider]
+// if modern-style Terraform 0.14+ addresses are expected.
+func (pt *Provider) UnmarshalText(text []byte) (err error) {
+	*pt, err = ParseProviderSource(string(text))
+	return
+}
+
 // IsLegacy returns true if the provider is a legacy-style provider
 func (pt Provider) IsLegacy() bool {
 	if pt.IsZero() {

--- a/provider.go
+++ b/provider.go
@@ -254,9 +254,10 @@ func (pt Provider) Equals(other Provider) bool {
 // terraform-config-inspect.
 //
 // The following are valid source string formats:
-// 		name
-// 		namespace/name
-// 		hostname/namespace/name
+//
+//	name
+//	namespace/name
+//	hostname/namespace/name
 //
 // "name"-only format is parsed as -/name (i.e. legacy namespace)
 // requiring further identification of the namespace via Registry API
@@ -368,7 +369,7 @@ func ParseProviderSource(str string) (Provider, error) {
 
 // MustParseProviderSource is a wrapper around ParseProviderSource that panics if
 // it returns an error.
-func MustParseProviderSource(raw string) (Provider) {
+func MustParseProviderSource(raw string) Provider {
 	p, err := ParseProviderSource(raw)
 	if err != nil {
 		panic(err)

--- a/provider.go
+++ b/provider.go
@@ -217,8 +217,14 @@ func (pt Provider) LessThan(other Provider) bool {
 
 // MarshalText implements encoding.TextMarshaler interface.
 //
-// It encodes the [Provider] into an FQN, equivalent to [String].
+// It encodes the [Provider] into an FQN, equivalent to [String]
+// or returns an error for an invalid [Provider].
 func (pt Provider) MarshalText() ([]byte, error) {
+	err := pt.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	return []byte(pt.String()), nil
 }
 

--- a/provider.go
+++ b/provider.go
@@ -332,7 +332,7 @@ func ValidateProviderAddress(raw string) error {
 		}
 	}
 
-	if !p.IsLegacy() {
+	if p.IsLegacy() {
 		return &ParserError{
 			Summary: "Invalid legacy provider namespace",
 			Detail:  `Expected FQN in the format "hostname/namespace/name"`,

--- a/provider_test.go
+++ b/provider_test.go
@@ -4,6 +4,7 @@
 package tfaddr
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"testing"
@@ -353,6 +354,39 @@ func TestValidateProviderAddress(t *testing.T) {
 				t.Fatal("expected validation error, none received")
 			}
 		})
+	}
+}
+
+func TestProviderMarshalText(t *testing.T) {
+	p := Provider{
+		Hostname:  svchost.Hostname("registry.terraform.io"),
+		Namespace: "hashicorp",
+		Type:      "aws",
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := `"registry.terraform.io/hashicorp/aws"`
+	if diff := cmp.Diff(expected, string(b)); diff != "" {
+		t.Fatalf("marshaled text mismatch: %s", diff)
+	}
+}
+
+func TestProviderUnmarshalText(t *testing.T) {
+	address := `"registry.terraform.io/hashicorp/aws"`
+	var p Provider
+	err := json.Unmarshal([]byte(address), &p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedProvider := Provider{
+		Hostname:  svchost.Hostname("registry.terraform.io"),
+		Namespace: "hashicorp",
+		Type:      "aws",
+	}
+	if diff := cmp.Diff(expectedProvider, p); diff != "" {
+		t.Fatalf("unmarshaled provider mismatch: %s", diff)
 	}
 }
 

--- a/provider_test.go
+++ b/provider_test.go
@@ -247,6 +247,64 @@ func TestProviderIsLegacy(t *testing.T) {
 	}
 }
 
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		Input       Provider
+		ExpectedErr bool
+	}{
+		{
+			MustParseProviderSource("host.com/hashicorp/coffee"),
+			false,
+		},
+		{
+			Provider{},
+			true,
+		},
+		{
+			Provider{
+				Type: "latte",
+			},
+			true,
+		},
+		{
+			Provider{
+				Type:      "latte",
+				Namespace: "coffeeshop",
+			},
+			true,
+		},
+		{
+			Provider{
+				Hostname: svchost.Hostname("registry.terraform.io"),
+			},
+			true,
+		},
+		{
+			MustParseProviderSource("unknown-namespace"),
+			true,
+		},
+		{
+			MustParseProviderSource("-/legacy"),
+			true,
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%02d", i), func(t *testing.T) {
+			err := tc.Input.Validate()
+			if err != nil {
+				if tc.ExpectedErr {
+					return
+				}
+				t.Fatalf("unexpected validation error: %s", err)
+			}
+			if tc.ExpectedErr {
+				t.Fatal("expected validation error, none received")
+			}
+		})
+	}
+}
+
 func TestValidateProviderAddress(t *testing.T) {
 	tests := []struct {
 		RawInput    string

--- a/provider_test.go
+++ b/provider_test.go
@@ -247,6 +247,57 @@ func TestProviderIsLegacy(t *testing.T) {
 	}
 }
 
+func TestValidateProviderAddress(t *testing.T) {
+	tests := []struct {
+		RawInput    string
+		ExpectedErr bool
+	}{
+		{
+			"host.com/hashicorp/coffee",
+			false,
+		},
+		{
+			"",
+			true,
+		},
+		{
+			"latte",
+			true,
+		},
+		{
+			"coffeeshop/latte",
+			true,
+		},
+		{
+			"registry.terraform.io//",
+			true,
+		},
+		{
+			"unknown-namespace",
+			true,
+		},
+		{
+			"-/legacy",
+			true,
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%02d", i), func(t *testing.T) {
+			err := ValidateProviderAddress(tc.RawInput)
+			if err != nil {
+				if tc.ExpectedErr {
+					return
+				}
+				t.Fatalf("unexpected validation error for %q: %s", tc.RawInput, err)
+			}
+			if tc.ExpectedErr {
+				t.Fatal("expected validation error, none received")
+			}
+		})
+	}
+}
+
 func ExampleParseProviderSource() {
 	pAddr, err := ParseProviderSource("hashicorp/aws")
 	if err != nil {
@@ -560,8 +611,4 @@ func TestProviderEquals(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestValidateProviderAddress(t *testing.T) {
-	t.Skip("TODO")
 }


### PR DESCRIPTION
In Terraform Core we came across a need to (un)marshal the provider address in its canonical format into JSON (https://github.com/hashicorp/terraform/pull/37179#discussion_r2135536877).

To enable integrity checking upstream this also introduces `Validate` method enabling validation of previously constructed `Provider`.

My understanding is that unmarshaling cannot be strict (yet) in the sense that it would reject legacy or unknown namespace. Please do correct me if I'm wrong.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
