### PR TITLE
Introduce Component and ComponentPackage types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 This module enables parsing, comparison and canonical representation of
 [Terraform Registry](https://registry.terraform.io/) **provider** addresses
-(such as `registry.terraform.io/grafana/grafana` or `hashicorp/aws`)
-and **module** addresses (such as `hashicorp/subnets/cidr`).
+(such as `registry.terraform.io/grafana/grafana` or `hashicorp/aws`),
+**module** addresses (such as `hashicorp/subnets/cidr`),
+and **component** addresses (such as `hashicorp/aws` or `example.com/myorg/mycomponent`).
 
 **Provider** addresses can be found in
 
@@ -16,6 +17,10 @@ and **module** addresses (such as `hashicorp/subnets/cidr`).
 
 **Module** addresses can be found within `source` argument
 of `module` block in Terraform configuration (`*.tf`)
+and parts of the address (namespace and name) in the Registry API.
+
+**Component** addresses can be found within the `source` argument
+of the `component` block in Terraform Stack configuration (`*.tfcomponent.hcl`)
 and parts of the address (namespace and name) in the Registry API.
 
 ## Compatibility
@@ -68,6 +73,24 @@ if err != nil {
 //   },
 //   Subdir: "modules/consul-cluster",
 // },
+```
+
+### Component
+
+```go
+cAddr, err := ParseComponentSource("hashicorp/aws//modules/vpc")
+if err != nil {
+	// deal with error
+}
+
+// cAddr == Component{
+//   Package: ComponentPackage{
+//     Host:      DefaultModuleRegistryHost,
+//     Namespace: "hashicorp",
+//     Name:      "aws",
+//   },
+//   Subdir: "modules/vpc",
+// }
 ```
 
 ## Other Module Address Formats

--- a/component.go
+++ b/component.go
@@ -110,6 +110,9 @@ func ParseComponentSource(raw string) (Component, error) {
 	// Prevent potential parsing collisions with known VCS hosts
 	// These hostnames are reserved for direct VCS installation
 	if host == svchost.Hostname("github.com") || host == svchost.Hostname("bitbucket.org") || host == svchost.Hostname("gitlab.com") {
+		// NOTE: This may change in the future if we allow VCS installations
+		// 	from these hosts to be registered in the component registry.
+		// 	For now, we disallow them to avoid confusion.
 		return ret, fmt.Errorf("can't use %q as a component registry host, because it's reserved for installing directly from version control repositories", host)
 	}
 

--- a/component.go
+++ b/component.go
@@ -1,0 +1,164 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfaddr
+
+import (
+	"fmt"
+	"strings"
+
+	svchost "github.com/hashicorp/terraform-svchost"
+)
+
+// Component represents a component listed in a Terraform component registry.
+// It combines a registry package address with an optional subdirectory path
+// to specify the exact location of a component within a registry package.
+//
+// Components are resolved through a two-step process:
+//  1. The registry package address is used to query the registry API
+//  2. The registry returns a ComponentSourceRemote with the actual source location
+//
+// Example component addresses:
+//   - registry.terraform.io/hashicorp/aws
+//   - registry.terraform.io/hashicorp/aws//modules/vpc
+//   - example.com/myorg/mycomponent//subdir/component
+type Component struct {
+	// Package is the registry package that the target component belongs to.
+	// The component installer must translate this into a ComponentSourceRemote
+	// using the registry API and then take that underlying address's
+	// Package in order to find the actual package location.
+	Package ComponentPackage
+
+	// If Subdir is non-empty then it represents a sub-directory within the
+	// remote package that the registry address eventually resolves to.
+	// This will ultimately become the suffix of the Subdir of the
+	// ComponentSourceRemote that the registry address translates to.
+	//
+	// Subdir uses a normalized forward-slash-based path syntax within the
+	// virtual filesystem represented by the final package. It will never
+	// include `../` or `./` sequences.
+	Subdir string
+}
+
+// ParseComponentSource parses a string representation of a component registry
+// address and returns a Component struct. This function only accepts component
+// registry addresses and will reject any other address type.
+//
+// Supported address formats:
+//   - "namespace/name" (uses default registry host)
+//   - "hostname/namespace/name" (explicit registry host)
+//   - "hostname/namespace/name//subdirectory" (with subdirectory)
+//
+// Examples:
+//   - "hashicorp/aws" -> registry.terraform.io/hashicorp/aws
+//   - "example.com/myorg/component"
+//   - "registry.terraform.io/hashicorp/aws//modules/vpc"
+//
+// The function validates that:
+//   - The address has 2 or 3 slash-separated segments
+//   - Subdirectories don't escape the package with "../" paths
+//   - The hostname (if provided) is not a reserved VCS host
+//   - Namespace and component names follow registry naming conventions
+func ParseComponentSource(raw string) (Component, error) {
+	var err error
+
+	// Extract subdirectory path if present (indicated by "//" separator)
+	var subDir string
+	raw, subDir = splitPackageSubdir(raw)
+	if strings.HasPrefix(subDir, "../") {
+		return Component{}, fmt.Errorf("subdirectory path %q leads outside of the component package", subDir)
+	}
+
+	// Split the main address into its components
+	parts := strings.Split(raw, "/")
+	// A valid registry component address has either two or three parts, because the leading hostname part is optional.
+	if len(parts) != 2 && len(parts) != 3 {
+		return Component{}, fmt.Errorf("a component registry source address must have either two or three slash-separated segments")
+	}
+
+	// Default to the standard Terraform registry if no hostname is specified
+	host := DefaultModuleRegistryHost
+	// Check if hostname segment is present
+	if len(parts) == 3 {
+		host, err = svchost.ForComparison(parts[0])
+		if err != nil {
+			// The svchost library doesn't produce very good error messages to
+			// return to an end-user, so we'll use some custom ones here.
+			switch {
+			case strings.Contains(parts[0], "--"):
+				// Looks like possibly punycode, which we don't allow here
+				// to ensure that source addresses are written readably.
+				return Component{}, fmt.Errorf("invalid component registry hostname %q; internationalized domain names must be given as direct unicode characters, not in punycode", parts[0])
+			default:
+				return Component{}, fmt.Errorf("invalid component registry hostname %q", parts[0])
+			}
+		}
+		if !strings.Contains(host.String(), ".") {
+			return Component{}, fmt.Errorf("invalid component registry hostname: must contain at least one dot")
+		}
+		// Discard the hostname prefix now that we've processed it
+		parts = parts[1:]
+	}
+
+	ret := Component{
+		Package: ComponentPackage{
+			Host: host,
+		},
+		Subdir: subDir,
+	}
+
+	// Prevent potential parsing collisions with known VCS hosts
+	// These hostnames are reserved for direct VCS installation
+	if host == svchost.Hostname("github.com") || host == svchost.Hostname("bitbucket.org") || host == svchost.Hostname("gitlab.com") {
+		return ret, fmt.Errorf("can't use %q as a component registry host, because it's reserved for installing directly from version control repositories", host)
+	}
+
+	// Validate and assign the namespace segment
+	if ret.Package.Namespace, err = parseModuleRegistryName(parts[0]); err != nil {
+		if strings.Contains(parts[0], ".") {
+			// Seems like the user omitted one of the latter components in
+			// an address with an explicit hostname.
+			return ret, fmt.Errorf("source address must have two more components after the hostname: the namespace and the name")
+		}
+		return ret, fmt.Errorf("invalid namespace %q: %s", parts[0], err)
+	}
+
+	// Validate and assign the component name segment
+	if ret.Package.Name, err = parseModuleRegistryName(parts[1]); err != nil {
+		if strings.Contains(parts[1], "?") {
+			// The user was trying to include a query string, probably?
+			return ret, fmt.Errorf("component registry addresses may not include a query string portion")
+		}
+		return ret, fmt.Errorf("invalid component name %q: %s", parts[1], err)
+	}
+
+	return ret, nil
+}
+
+// String returns a full representation of the component address, including any
+// additional components that are typically implied by omission in
+// user-written addresses.
+//
+// We typically use this longer representation in error messages, in case
+// the inclusion of normally-omitted components is helpful in debugging
+// unexpected behavior.
+func (c Component) String() string {
+	if c.Subdir != "" {
+		return c.Package.String() + "//" + c.Subdir
+	}
+	return c.Package.String()
+}
+
+// ForDisplay is similar to String but instead returns a representation of
+// the idiomatic way to write the address in configuration, omitting
+// components that are commonly just implied in addresses written by
+// users.
+//
+// We typically use this shorter representation in informational messages,
+// such as the note that we're about to start downloading a package.
+func (c Component) ForDisplay() string {
+	if c.Subdir != "" {
+		return c.Package.ForDisplay() + "//" + c.Subdir
+	}
+	return c.Package.ForDisplay()
+}

--- a/component_package.go
+++ b/component_package.go
@@ -1,0 +1,82 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfaddr
+
+import (
+	"strings"
+
+	svchost "github.com/hashicorp/terraform-svchost"
+)
+
+// ComponentPackage represents a symbolic address for a component in a Terraform
+// component registry. It serves as an indirection layer that allows the component
+// installer to query a registry and translate this symbolic address (along with
+// version constraints provided separately) into a concrete physical source location.
+//
+// ComponentPackage is intentionally distinct from other package address types
+// because they serve different purposes: registry package addresses are exclusively
+// used for registry queries to discover the actual component package location.
+// This separation helps maintainers understand the component installation workflow
+// and enables the type system to enforce proper usage patterns.
+//
+// Example registry addresses:
+//   - registry.terraform.io/hashicorp/aws
+//   - example.com/myorg/mycomponent
+type ComponentPackage struct {
+	// Host is the hostname of the component registry (e.g., "registry.terraform.io")
+	Host svchost.Hostname
+
+	// Namespace identifies the organization or user that published the component
+	Namespace string
+
+	// Name is the component's name within the namespace
+	Name string
+}
+
+// String returns the full registry address as a human-readable string.
+// This method formats the address for display purposes, using the Unicode
+// representation of hostnames rather than punycode encoding.
+//
+// The returned format is: "hostname/namespace/name"
+// For example: "registry.terraform.io/hashicorp/aws"
+func (s ComponentPackage) String() string {
+	// Note: we're using the "display" form of the hostname here because
+	// for our service hostnames "for display" means something different:
+	// it means to render non-ASCII characters directly as Unicode
+	// characters, rather than using the "punycode" representation we
+	// use for internal processing, and so the "display" representation
+	// is actually what users would write in their configurations.
+	return s.Host.ForDisplay() + "/" + s.ForRegistryProtocol()
+}
+
+// ForDisplay returns a string representation suitable for display to users,
+// omitting the registry hostname when it's the default registry host.
+// This is the format users would typically write in their configurations.
+//
+// For the default registry, returns: "namespace/name"
+// For custom registries, returns: "hostname/namespace/name"
+func (s ComponentPackage) ForDisplay() string {
+	if s.Host == DefaultModuleRegistryHost {
+		return s.ForRegistryProtocol()
+	}
+	return s.Host.ForDisplay() + "/" + s.ForRegistryProtocol()
+}
+
+// ForRegistryProtocol returns a string representation of just the namespace,
+// name, and target system portions of the address, always omitting the
+// registry hostname and the subdirectory portion, if any.
+//
+// This is primarily intended for generating addresses to send to the
+// registry in question via the registry protocol, since the protocol
+// skips sending the registry its own hostname as part of identifiers.
+//
+// The returned format is: "namespace/name"
+// For example: "hashicorp/aws"
+func (s ComponentPackage) ForRegistryProtocol() string {
+	var buf strings.Builder
+	buf.WriteString(s.Namespace)
+	buf.WriteByte('/')
+	buf.WriteString(s.Name)
+	return buf.String()
+}

--- a/component_test.go
+++ b/component_test.go
@@ -250,6 +250,14 @@ func TestParseComponentSource(t *testing.T) {
 			input:   "registry.terraform.io/hashicorp/k8-cluster/extra/segment",
 			wantErr: "a component registry source address must have either two or three slash-separated segments",
 		},
+		"includes protocol": {
+			input:   "https://registry.terraform.io/hashicorp/k8-cluster",
+			wantErr: "a component registry source address must have either two or three slash-separated segments",
+		},
+		"includes query params": {
+			input:   "registry.terraform.io/hashicorp/k8-cluster?key=value",
+			wantErr: "component registry addresses may not include a query string portion",
+		},
 	}
 
 	for name, test := range tests {

--- a/component_test.go
+++ b/component_test.go
@@ -1,0 +1,284 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfaddr
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	svchost "github.com/hashicorp/terraform-svchost"
+)
+
+func TestParseComponentSource_simple(t *testing.T) {
+	tests := map[string]struct {
+		input   string
+		want    Component
+		wantErr string
+	}{
+		"main registry implied": {
+			input: "hashicorp/k8-cluster",
+			want: Component{
+				Package: ComponentPackage{
+					Host:      svchost.Hostname("registry.terraform.io"),
+					Namespace: "hashicorp",
+					Name:      "k8-cluster",
+				},
+				Subdir: "",
+			},
+		},
+		"main registry implied, subdir": {
+			input: "hashicorp/k8-cluster//path/to/dir",
+			want: Component{
+				Package: ComponentPackage{
+					Host:      svchost.Hostname("registry.terraform.io"),
+					Namespace: "hashicorp",
+					Name:      "k8-cluster",
+				},
+				Subdir: "path/to/dir",
+			},
+		},
+		"custom registry": {
+			input: "terraform.registry.io/hashicorp/k8-cluster",
+			want: Component{
+				Package: ComponentPackage{
+					Host:      svchost.Hostname("terraform.registry.io"),
+					Namespace: "hashicorp",
+					Name:      "k8-cluster",
+				},
+				Subdir: "",
+			},
+		},
+		"custom registry, subdir": {
+			input: "app.terraform.io/hashicorp/k8-cluster//examples/foo",
+			want: Component{
+				Package: ComponentPackage{
+					Host:      svchost.Hostname("app.terraform.io"),
+					Namespace: "hashicorp",
+					Name:      "k8-cluster",
+				},
+				Subdir: "examples/foo",
+			},
+		},
+		"private registry": {
+			input: "example.com/awesomecorp/network",
+			want: Component{
+				Package: ComponentPackage{
+					Host:      svchost.Hostname("example.com"),
+					Namespace: "awesomecorp",
+					Name:      "network",
+				},
+				Subdir: "",
+			},
+		},
+		"private registry, subdir": {
+			input: "example.com/awesomecorp/network//configs",
+			want: Component{
+				Package: ComponentPackage{
+					Host:      svchost.Hostname("example.com"),
+					Namespace: "awesomecorp",
+					Name:      "network",
+				},
+				Subdir: "configs",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			addr, err := ParseComponentSource(test.input)
+
+			if test.wantErr != "" {
+				switch {
+				case err == nil:
+					t.Errorf("unexpected success\nwant error: %s", test.wantErr)
+				case err.Error() != test.wantErr:
+					t.Errorf("wrong error messages\ngot:  %s\nwant: %s", err.Error(), test.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err.Error())
+			}
+
+			if diff := cmp.Diff(addr, test.want); diff != "" {
+				t.Errorf("wrong result\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestParseComponentSource(t *testing.T) {
+	tests := map[string]struct {
+		input           string
+		wantString      string
+		wantForDisplay  string
+		wantForProtocol string
+		wantErr         string
+	}{
+		"public registry": {
+			input:           `hashicorp/k8-cluster`,
+			wantString:      `registry.terraform.io/hashicorp/k8-cluster`,
+			wantForDisplay:  `hashicorp/k8-cluster`,
+			wantForProtocol: `hashicorp/k8-cluster`,
+		},
+		"public registry with subdir": {
+			input:           `hashicorp/k8-cluster//configs`,
+			wantString:      `registry.terraform.io/hashicorp/k8-cluster//configs`,
+			wantForDisplay:  `hashicorp/k8-cluster//configs`,
+			wantForProtocol: `hashicorp/k8-cluster`,
+		},
+		"public registry using explicit hostname": {
+			input:           `registry.terraform.io/hashicorp/k8-cluster`,
+			wantString:      `registry.terraform.io/hashicorp/k8-cluster`,
+			wantForDisplay:  `hashicorp/k8-cluster`,
+			wantForProtocol: `hashicorp/k8-cluster`,
+		},
+		"terraform.registry.io example": {
+			input:           `terraform.registry.io/hashicorp/k8-cluster`,
+			wantString:      `terraform.registry.io/hashicorp/k8-cluster`,
+			wantForDisplay:  `terraform.registry.io/hashicorp/k8-cluster`,
+			wantForProtocol: `hashicorp/k8-cluster`,
+		},
+		"app.terraform.io example": {
+			input:           `app.terraform.io/hashicorp/k8-cluster`,
+			wantString:      `app.terraform.io/hashicorp/k8-cluster`,
+			wantForDisplay:  `app.terraform.io/hashicorp/k8-cluster`,
+			wantForProtocol: `hashicorp/k8-cluster`,
+		},
+		"app.terraform.io with subdir": {
+			input:           `app.terraform.io/hashicorp/k8-cluster//path/to/dir`,
+			wantString:      `app.terraform.io/hashicorp/k8-cluster//path/to/dir`,
+			wantForDisplay:  `app.terraform.io/hashicorp/k8-cluster//path/to/dir`,
+			wantForProtocol: `hashicorp/k8-cluster`,
+		},
+		"public registry with mixed case names": {
+			input:           `HashiCorp/K8-Cluster`,
+			wantString:      `registry.terraform.io/HashiCorp/K8-Cluster`,
+			wantForDisplay:  `HashiCorp/K8-Cluster`,
+			wantForProtocol: `HashiCorp/K8-Cluster`,
+		},
+		"private registry with non-standard port": {
+			input:           `Example.com:1234/HashiCorp/K8-Cluster`,
+			wantString:      `example.com:1234/HashiCorp/K8-Cluster`,
+			wantForDisplay:  `example.com:1234/HashiCorp/K8-Cluster`,
+			wantForProtocol: `HashiCorp/K8-Cluster`,
+		},
+		"private registry with IDN hostname": {
+			input:           `Испытание.com/HashiCorp/K8-Cluster`,
+			wantString:      `испытание.com/HashiCorp/K8-Cluster`,
+			wantForDisplay:  `испытание.com/HashiCorp/K8-Cluster`,
+			wantForProtocol: `HashiCorp/K8-Cluster`,
+		},
+		"private registry with IDN hostname and non-standard port": {
+			input:           `Испытание.com:1234/HashiCorp/K8-Cluster//Foo`,
+			wantString:      `испытание.com:1234/HashiCorp/K8-Cluster//Foo`,
+			wantForDisplay:  `испытание.com:1234/HashiCorp/K8-Cluster//Foo`,
+			wantForProtocol: `HashiCorp/K8-Cluster`,
+		},
+		"invalid hostname": {
+			input:   `---.com/HashiCorp/K8-Cluster`,
+			wantErr: `invalid component registry hostname "---.com"; internationalized domain names must be given as direct unicode characters, not in punycode`,
+		},
+		"hostname with only one label": {
+			// This was historically forbidden in our initial implementation,
+			// so we keep it forbidden to avoid newly interpreting such
+			// addresses as registry addresses rather than remote source
+			// addresses.
+			input:   `foo/var/baz`,
+			wantErr: `invalid component registry hostname: must contain at least one dot`,
+		},
+		"invalid namespace": {
+			input:   `boop!/var`,
+			wantErr: `invalid namespace "boop!": must be between one and 64 characters, including ASCII letters, digits, dashes, and underscores, where dashes and underscores may not be the prefix or suffix`,
+		},
+		"invalid component name": {
+			input:   `hashicorp/no-no-no!`,
+			wantErr: `invalid component name "no-no-no!": must be between one and 64 characters, including ASCII letters, digits, dashes, and underscores, where dashes and underscores may not be the prefix or suffix`,
+		},
+		"missing part with explicit hostname": {
+			input:   `foo.com/var`,
+			wantErr: `source address must have two more components after the hostname: the namespace and the name`,
+		},
+		"errant query string": {
+			input:   `foo/var?otherthing`,
+			wantErr: `component registry addresses may not include a query string portion`,
+		},
+		"github.com": {
+			// We don't allow using github.com like a component registry because
+			// that conflicts with the historically-supported shorthand for
+			// installing directly from GitHub-hosted git repositories.
+			input:   `github.com/HashiCorp/K8-Cluster`,
+			wantErr: `can't use "github.com" as a component registry host, because it's reserved for installing directly from version control repositories`,
+		},
+		"bitbucket.org": {
+			// We don't allow using bitbucket.org like a component registry because
+			// that conflicts with the historically-supported shorthand for
+			// installing directly from BitBucket-hosted git repositories.
+			input:   `bitbucket.org/HashiCorp/K8-Cluster`,
+			wantErr: `can't use "bitbucket.org" as a component registry host, because it's reserved for installing directly from version control repositories`,
+		},
+		"gitlab.com": {
+			// We don't allow using gitlab.com like a component registry because
+			// that conflicts with the historically-supported shorthand for
+			// installing directly from GitLab-hosted git repositories.
+			input:   `gitlab.com/HashiCorp/K8-Cluster`,
+			wantErr: `can't use "gitlab.com" as a component registry host, because it's reserved for installing directly from version control repositories`,
+		},
+		"local path from current dir": {
+			// Can't use a local path when we're specifically trying to parse
+			// a _registry_ source address.
+			input:   `./boop`,
+			wantErr: `source address must have two more components after the hostname: the namespace and the name`,
+		},
+		"local path from parent dir": {
+			// Can't use a local path when we're specifically trying to parse
+			// a _registry_ source address.
+			input:   `../boop`,
+			wantErr: `source address must have two more components after the hostname: the namespace and the name`,
+		},
+		"main registry implied, escaping subdir": {
+			input:   "hashicorp/k8-cluster//../nope",
+			wantErr: `subdirectory path "../nope" leads outside of the component package`,
+		},
+		"too few segments": {
+			input:   "boop",
+			wantErr: "a component registry source address must have either two or three slash-separated segments",
+		},
+		"too many segments": {
+			input:   "registry.terraform.io/hashicorp/k8-cluster/extra/segment",
+			wantErr: "a component registry source address must have either two or three slash-separated segments",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			addr, err := ParseComponentSource(test.input)
+
+			if test.wantErr != "" {
+				switch {
+				case err == nil:
+					t.Errorf("unexpected success\nwant error: %s", test.wantErr)
+				case err.Error() != test.wantErr:
+					t.Errorf("wrong error messages\ngot:  %s\nwant: %s", err.Error(), test.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err.Error())
+			}
+
+			if got, want := addr.String(), test.wantString; got != want {
+				t.Errorf("wrong String() result\ngot:  %s\nwant: %s", got, want)
+			}
+			if got, want := addr.ForDisplay(), test.wantForDisplay; got != want {
+				t.Errorf("wrong ForDisplay() result\ngot:  %s\nwant: %s", got, want)
+			}
+			if got, want := addr.Package.ForRegistryProtocol(), test.wantForProtocol; got != want {
+				t.Errorf("wrong ForRegistryProtocol() result\ngot:  %s\nwant: %s", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Related Issue

Fixes # <!-- INSERT ISSUE NUMBER -->

## Description

This provides a structured way to handle component addresses
in the Terraform registry, enabling validation and error
reporting. The new types and functions facilitate the
installation workflow for components.

- Added Component and ComponentPackage structs to represent registry
  components and their addresses.
- Implemented ParseComponentSource function to parse and validate
  component registry addresses.
- Created unit tests for ParseComponentSource to ensure correct parsing
  and error handling.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.